### PR TITLE
Chore: Use Alias In Project

### DIFF
--- a/__tests__/api/node/index.spec.ts
+++ b/__tests__/api/node/index.spec.ts
@@ -1,7 +1,7 @@
 import supertest from "supertest"
-import init from '../../../server/init'
-import app from '../../../server/app'
-import { Workflow, Node } from '../../../server/database'
+import init from '~server/init'
+import app from '~server/app'
+import { Workflow, Node } from '~server/database'
 
 const TEST_WORKFLOW_NAME = 'test'
 

--- a/__tests__/api/workflow/index.spec.ts
+++ b/__tests__/api/workflow/index.spec.ts
@@ -1,8 +1,8 @@
 import supertest from 'supertest'
 import { v4 as uuidv4 } from 'uuid'
-import init from '../../../server/init'
-import app from '../../../server/app'
-import { Workflow } from '../../../server/database'
+import init from '~server/init'
+import app from '~server/app'
+import { Workflow } from '~server/database'
 
 const TEST_WORKFLOW_NAME = uuidv4()
 

--- a/__tests__/backend/createWorkflow.spec.ts
+++ b/__tests__/backend/createWorkflow.spec.ts
@@ -2,8 +2,8 @@
 process.env.DB_TYPE = 'sqlite'
 process.env.DB_HOST = ':memory:'
 import { v4 as uuidv4  } from 'uuid'
-import { Workflow, initDB } from '../../server/database'
-import createWorkflow from '../../server/src/workflow/createWorkflow'
+import { Workflow, initDB } from '~server/database'
+import createWorkflow from '~server/src/workflow/createWorkflow'
 
 const TEST_WORKFLOW_NAME = uuidv4()
 

--- a/__tests__/shared/expression.spec.ts
+++ b/__tests__/shared/expression.spec.ts
@@ -1,4 +1,4 @@
-import { parseExpression, renderExpression } from '../../shared/util/expression'
+import { parseExpression, renderExpression } from '~shared/util/expression'
 
 describe('expression test', () => {
   it('parseExpression', () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,13 @@ module.exports = {
     'server/**/*{.js,.jsx,.ts,.tsx}',
     'shared/**/*{.js,.jsx,.ts,.tsx}',
     '!server/dev.ts',
-    '!server/index.ts',
+    '!server/index.ts'
   ],
+  moduleNameMapper: {
+    '~server/(.*)': ['<rootDir>/server/$1'],
+    '~web/(.*)': ['<rootDir>/web/$1'],
+    '~shared/(.*)': ['<rootDir>/shared/$1'],
+    '~test/(.*)': ['<rootDir>/__tests__/$1'],
+    '~/(.*)': ['<rootDir>/$1']
+  }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/body-parser": "^1.19.2",
     "@types/express": "^4.17.17",
     "@types/jest": "^29.5.2",
+    "@types/module-alias": "^2.0.1",
     "@types/react": "^18.2.6",
     "@types/react-dom": "^18.2.4",
     "@types/supertest": "^2.0.12",
@@ -92,5 +93,12 @@
     "webpack-cli": "^5.1.1",
     "webpack-dev-middleware": "^6.1.1",
     "webpack-dev-server": "^4.15.0"
+  },
+  "_moduleAliases": {
+    "~server": "server/",
+    "~web": "web/",
+    "~shared": "shared/",
+    "~test": "__tests__/",
+    "~": "."
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ devDependencies:
   '@types/jest':
     specifier: ^29.5.2
     version: 29.5.2
+  '@types/module-alias':
+    specifier: ^2.0.1
+    version: 2.0.1
   '@types/react':
     specifier: ^18.2.6
     version: 18.2.6
@@ -2562,6 +2565,10 @@ packages:
 
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
+    dev: true
+
+  /@types/module-alias@2.0.1:
+    resolution: {integrity: sha512-DN/CCT1HQG6HquBNJdLkvV+4v5l/oEuwOHUPLxI+Eub0NED+lk0YUfba04WGH90EINiUrNgClkNnwGmbICeWMQ==}
     dev: true
 
   /@types/ms@0.7.31:

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,3 +1,4 @@
+import 'module-alias/register'
 import path from 'path'
 import Express from 'express'
 import bodyParser from 'body-parser'

--- a/server/init/index.ts
+++ b/server/init/index.ts
@@ -1,3 +1,4 @@
+import 'module-alias/register'
 import { loadPlugins } from '../utils/cachePlugins'
 import { initDB } from '../database/'
 import User from '../database/model/User'

--- a/server/src/node/createNode.ts
+++ b/server/src/node/createNode.ts
@@ -1,8 +1,8 @@
 import { type Model } from 'sequelize'
 import { HttpError } from 'routing-controllers'
-import { getPlugins } from '../../utils/cachePlugins'
-import { type NodeData } from '../../types/http/NodeDatas'
-import { Node, Workflow } from '../../database'
+import { getPlugins } from '~server/utils/cachePlugins'
+import { type NodeData } from '~server/types/http/NodeDatas'
+import { Node, Workflow } from '~server/database'
 
 export class NoSearchPluginError extends HttpError {
   constructor(message: string) {

--- a/server/src/plugin/index.controller.ts
+++ b/server/src/plugin/index.controller.ts
@@ -1,6 +1,6 @@
 import { Get, JsonController } from 'routing-controllers'
-import { SuccessReturn } from '../../types/http/BaseReturn';
-import { getPlugins } from '../../utils/cachePlugins'
+import { SuccessReturn } from '~server/types/http/BaseReturn';
+import { getPlugins } from '~server/utils/cachePlugins'
 
 @JsonController('/plugins')
 class PluginController {

--- a/server/src/workflow/createWorkflow.ts
+++ b/server/src/workflow/createWorkflow.ts
@@ -1,4 +1,4 @@
-import { Workflow } from '../../database'
+import { Workflow } from '~server/database'
 
 async function createWorkflow(name: string, description?: string) {
   const workflow = await Workflow.create({

--- a/server/src/workflow/getWorkflow.ts
+++ b/server/src/workflow/getWorkflow.ts
@@ -1,4 +1,4 @@
-import { Workflow } from '../../database'
+import { Workflow } from '~server/database'
 
 export async function getWorkflows() {
   return (await Workflow.findAll()).map((item) => item.dataValues)

--- a/server/src/workflow/index.controller.ts
+++ b/server/src/workflow/index.controller.ts
@@ -1,7 +1,7 @@
 import { Put, JsonController, BodyParam, Get } from 'routing-controllers'
-import { SuccessReturn } from '../../types/http/BaseReturn';
 import createWorkflow from './createWorkflow'
 import { getWorkflows } from './getWorkflow';
+import { SuccessReturn } from '~server/types/http/BaseReturn';
 
 @JsonController('/workflow')
 class WorkflowController {

--- a/server/utils/webhook-load.ts
+++ b/server/utils/webhook-load.ts
@@ -1,5 +1,5 @@
 import express from 'express'
-import Trigger from '../database/model/Trigger'
+import Trigger from '~server/database/model/Trigger'
 
 const webhookExpress = express()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,11 @@
     "sourceMap": true,
     "baseUrl": ".",
     "paths": {
-      "@server/*": ["server/*"],
-      "@shared/*": ["shared/*"]
+      "~server/*": ["server/*"],
+      "~web/*": ["web/*"],
+      "~shared/*": ["shared/*"],
+      "~test/*": ["__tests__/*"],
+      "~/*": ["./*"]
     }
   },
   "include": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx"],


### PR DESCRIPTION
Use alias to optimize import code

**Before**
```
import { parseExpression, renderExpression } from '../../shared/util/expression'
```

**After
```
import { parseExpression, renderExpression } from '~/shared/util/expression'
```